### PR TITLE
Improve loda rectangle spec

### DIFF
--- a/coreldraw_cdr.ksy
+++ b/coreldraw_cdr.ksy
@@ -725,12 +725,18 @@ types:
               - id: r0_raw
                 type: f8
             instances:
-              width:
+              width_raw:
                 value: _parent.x0.value * scale_x / 2.0
-              height:
+              width:
+                value: '(width_raw < 0.0) ? -width_raw : width_raw'
+              height_raw:
                 value: _parent.y0.value * scale_y / 2.0
+              height:
+                value: '(height_raw < 0.0) ? -height_raw : height_raw'
+              min_dimension:
+                value: '(width < height) ? width : height'
               scale:
-                value: 'scale_with == 0 ? 1 : 254000.0'
+                value: 'scale_with == 0 ? min_dimension : 254000.0'
               r3:
                 value: r3_raw * scale
               r2:


### PR DESCRIPTION
My memory of originally making these changes is not perfect, but IIRC the following two points are true about the current loda rectangle spec.
- The `width` and `height` instances can sometimes be negative (on actual files, that is; not just in theory)
- The value of the `scale` instance is incorrect if `scale_with == 0`.

This PR addresses both of those points.